### PR TITLE
fix: remove listExtensions function from the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@ Returns:
   - `completed`: Boolean indicating if execution completed
   - `returnItems`: Array of items returned from the extension
 
-#### listExtensions
-Lists all available extensions.
-
-```typescript
-async function listExtensions(): Promise<ExtensionItem[]>
-```
-
-Returns array of `ExtensionItem` objects containing:
-- `bundleIdentifier`: Extension's bundle ID
-- `name`: Extension name
-- `extensionPointIdentifier`: Extension point ID
-
 #### isExtensionAvailable
 Checks if an extension is available.
 
@@ -78,9 +66,6 @@ Returns boolean indicating availability.
 const available = await LnExtensionExecutorBridgeModule.isExtensionAvailable(
   "com.burbn.instagram.shareextension"
 );
-
-// List all extensions
-const extensions = await LnExtensionExecutorBridgeModule.listExtensions();
 
 // Execute an extension
 const result = await LnExtensionExecutorBridgeModule.executeExtension({

--- a/ios/LnExtensionExecutorBridgeModule.swift
+++ b/ios/LnExtensionExecutorBridgeModule.swift
@@ -72,34 +72,6 @@ public class LnExtensionExecutorBridgeModule: Module {
             }
         }
         
-        AsyncFunction("listExtensions") { (promise: Promise) in
-            let shareExtensionPoint = "com.apple.share-services"
-            
-            // Get all installed app bundles
-            guard let installedApps = Bundle.main.bundleIdentifier.flatMap({ Bundle(identifier: $0) }) else {
-                promise.reject("ERR_LIST_FAILED", "Failed to get list of extensions")
-                return
-            }
-            
-            // Get the extension info from Info.plist
-            guard let extensionsInfo = installedApps.infoDictionary?["NSExtension"] as? [String: Any],
-                  let extensionPoint = extensionsInfo["NSExtensionPointIdentifier"] as? String,
-                  extensionPoint == shareExtensionPoint else {
-                promise.resolve([]) // No share extensions found
-                return
-            }
-            
-            let result: [[String: Any]] = [
-                [
-                    "bundleIdentifier": installedApps.bundleIdentifier ?? "",
-                    "name": installedApps.infoDictionary?["CFBundleDisplayName"] as? String ?? "",
-                    "extensionPointIdentifier": shareExtensionPoint
-                ]
-            ]
-            
-            promise.resolve(result)
-        }
-        
         AsyncFunction("isExtensionAvailable") { (bundleIdentifier: String, promise: Promise) in
             do {
                 // Try to create an executor with the bundle ID - if it succeeds, the extension is available

--- a/src/LnExtensionExecutorBridge.types.ts
+++ b/src/LnExtensionExecutorBridge.types.ts
@@ -17,6 +17,5 @@ export type ExtensionItem = {
 
 export type LnExtensionExecutorBridgeModule = {
   executeExtension(context: ExtensionContext): Promise<ExtensionResult>;
-  listExtensions(): Promise<ExtensionItem[]>;
   isExtensionAvailable(bundleIdentifier: string): Promise<boolean>;
 };

--- a/src/LnExtensionExecutorBridgeModule.ts
+++ b/src/LnExtensionExecutorBridgeModule.ts
@@ -1,15 +1,11 @@
 import { requireNativeModule } from 'expo-modules-core';
-import { ExtensionContext, ExtensionItem, ExtensionResult, LnExtensionExecutorBridgeModule } from './LnExtensionExecutorBridge.types';
+import { ExtensionContext, ExtensionResult, LnExtensionExecutorBridgeModule } from './LnExtensionExecutorBridge.types';
 
 const NativeLnExtensionExecutorBridge = requireNativeModule('LnExtensionExecutorBridge') as LnExtensionExecutorBridgeModule;
 
 export default {
   executeExtension: async (context: ExtensionContext): Promise<ExtensionResult> => {
     return await NativeLnExtensionExecutorBridge.executeExtension(context);
-  },
-  
-  listExtensions: async (): Promise<ExtensionItem[]> => {
-    return await NativeLnExtensionExecutorBridge.listExtensions();
   },
   
   isExtensionAvailable: async (bundleIdentifier: string): Promise<boolean> => {


### PR DESCRIPTION
This function was added as an LLM hallucination. Enumerating available extensions is only possible if we manually check with a list of predefined bundle ids (outside scope)

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/carter-0/ln-extension-executor-bridge/pull/1?shareId=947f01a3-5fa3-4036-8e89-6ace0c4920ff).