### PR TITLE
fix: make activity items accept objects with type and value parameters

### DIFF
--- a/src/LnExtensionExecutorBridge.types.ts
+++ b/src/LnExtensionExecutorBridge.types.ts
@@ -1,7 +1,7 @@
 export type ExtensionContext = {
   bundleIdentifier: string;
   extensionPointIdentifier?: string;
-  activityItems?: any[];
+  activityItems?: ActivityItem[];
 };
 
 export type ExtensionResult = {
@@ -13,6 +13,11 @@ export type ExtensionItem = {
   bundleIdentifier: string;
   name: string;
   extensionPointIdentifier: string;
+};
+
+export type ActivityItem = {
+  type: 'string' | 'file';
+  value: string | URL;
 };
 
 export type LnExtensionExecutorBridgeModule = {


### PR DESCRIPTION
Update `activityItems` to accept objects with `type` and `value` parameters.

* Modify `src/LnExtensionExecutorBridge.types.ts` to update the `activityItems` type to accept objects with `type` and `value` parameters.
  * Define `type` as a string that can be 'string' or 'file'.
  * Define `value` as a string or URL.

* Modify `ios/LnExtensionExecutorBridgeModule.swift` to update the `executeExtension` function to process `activityItems` as objects with `type` and `value` parameters.
  * Cast `value` to URL if `type` is 'file'.
  * Use `value` as is if `type` is 'string'.
  * Remove existing cast logic that processes everything as a string, URL, Data, or UIImage.

This fixes #2.

TODO:
- [ ] Test

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/carter-0/ln-extension-executor-bridge/pull/4?shareId=4bc5cc8e-af11-4283-be16-faf8f74cf31d).